### PR TITLE
Fix item kind

### DIFF
--- a/langserver/internal/source/completion.go
+++ b/langserver/internal/source/completion.go
@@ -380,9 +380,16 @@ func createRuleCompletionItem(rule *ast.Rule) CompletionItem {
 		insertText.WriteByte(']')
 	}
 
+	var itemKind CompletionKind
+	if len(rule.Head.Args) != 0 || head.Key != nil {
+		itemKind = FunctionItem
+	} else {
+		itemKind = VariableItem
+	}
+
 	return CompletionItem{
 		Label:      rule.Head.Name.String(),
-		Kind:       FunctionItem,
+		Kind:       itemKind,
 		InsertText: insertText.String(),
 	}
 }

--- a/langserver/internal/source/completion_test.go
+++ b/langserver/internal/source/completion_test.go
@@ -436,6 +436,42 @@ violation[msg] {
 				},
 			},
 		},
+		"some rule is function and others is variable": {
+			files: map[string]source.File{
+				"src.rego": {
+					RowText: `package src
+
+violation[msg] {
+	is
+}
+
+is_hello(msg) {
+	msg == "hello"
+}
+
+default is_test = true`,
+				},
+			},
+			location: &ast.Location{
+				Row: 4,
+				Col: 3,
+				Offset: len("pacakge src\n\nviolation[msg] {	is"),
+				Text: []byte("s"),
+				File: "src.rego",
+			},
+			expectItems: []source.CompletionItem{
+				{
+					Label:      "is_hello",
+					Kind:       source.FunctionItem,
+					InsertText: "is_hello(msg)",
+				},
+				{
+					Label:      "is_test",
+					Kind:       source.VariableItem,
+					InsertText: "is_test",
+				},
+			},
+		},
 	}
 
 	for n, tt := range tests {


### PR DESCRIPTION
before

```rego
p(arg) { } // function

p[arg] { } // function

p = arg { } // function
```

after

```rego
p(arg) { } // function

p[arg] { } // function

p = arg { } // variable
```